### PR TITLE
Support for binary messages, bugfix on websockets-internal.R:.frame bit ordering

### DIFF
--- a/R/websockets-internal.R
+++ b/R/websockets-internal.R
@@ -143,8 +143,8 @@
 {
   if(is.character(opcode)) opcode = strtoi(opcode, 16L)
   head = rawToBits(raw(1))    # First byte of header
-  if(FIN) head[1] = as.raw(1)
-  head[5:8] = rawToBits(as.raw(opcode))[4:1]
+  if(FIN) head[8] = as.raw(1)
+  head[1:4] = rawToBits(as.raw(opcode))[1:4]
   head2 = rawToBits(raw(1))    # 2nd byte of header
   rest  = raw(0)              # Optional 3rd -- 6th bytes
   if(mask) head2[8] = as.raw(1)


### PR DESCRIPTION
These commits add support for binary messages from websocket_write. This is useful for sending raw data more efficiently down the wire. Since version 15, Chrome can stuff binary messages directly into ArrayBuffers, giving a fast way to get arrays of raw floats.

One of the commits fixes a bug on .frame which arises when the opcode parameter in .frame is different from 1, and the other commit adds the is.binary functionality to the websocket server functions.
