### PR TITLE
Changed Upgrade from $ to [[, as $ is prefix based

### DIFF
--- a/R/websockets.R
+++ b/R/websockets.R
@@ -273,7 +273,7 @@ create_server = function(
       server$client_sockets[[as.character(j)]] = J
 
       # Web request
-      if (is.null(J$wsinfo$Upgrade)) {
+      if (is.null(J$wsinfo[["Upgrade"]])) {
 
         # Not a handshake request, serve a static web page
         if (is.function(server$static)) {


### PR DESCRIPTION
Chrome, since 44.0.2403.130, adds Upgrade-Insecure-Headers to basic http (NOT websocket) requests.

Previously, checks that a request was NOT a websocket upgrade were performed with 

```
  # Web request
  if (is.null(J$wsinfo$Upgrade)) {
    # Not a handshake request, serve a static web page
```

Because R allows for prefix matching when performing $ lookups, this means the presence of Upgrade-Insecure-Headers fools R-Websockets into considering ALL requests to be websocket upgrades.

Use an exact match, via [["Upgrade"]] instead.
